### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Adobe Experience Manager - Sample Granite Maintenance Task
+# Adobe Experience Manager - Sample Maintenance Task
 
-This is a bundle implementing a sample Maintenance Task to be configured using the Granite Operations Dashboard.
+This is a bundle implementing a sample Maintenance Task to be configured using the Operations Dashboard.
 
 ## Building 
  


### PR DESCRIPTION
should we remove 'granite' from the readme as granite is an internal name while this is an external tool?
